### PR TITLE
chore(release): 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.1.1](https://github.com/nikbabchenko/skeleton-webcomponent/compare/v2.0.0...v2.1.1) (2022-02-12)
+
 ## 1.0.5 (2020-10-22)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skeleton-webcomponent-loader",
-  "version": "1.0.5",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -961,14 +961,14 @@
       }
     },
     "@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg=="
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
+      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA=="
     },
     "@stencil/sass": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz",
-      "integrity": "sha512-aFKoqtxZ/8BRbvNFiWRycGiqvMI22Ifn5qsKfq0U23j43XD81jT6d7K0WQd55ejNpoSpdxJcbOuFgQy3mXizfA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
+      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ=="
     },
     "@types/babel__core": {
       "version": "7.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skeleton-webcomponent-loader",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "Skeleton loader webcomponent developed in stencil.js",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",
@@ -33,8 +33,8 @@
     }
   },
   "dependencies": {
-    "@stencil/core": "^2.4.0",
-    "@stencil/sass": "^1.4.1"
+    "@stencil/core": "^2.13.0",
+    "@stencil/sass": "^1.5.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
* Updates stencil.js to the 2.13.0 (@stencil/core, @stencil/sass)